### PR TITLE
Fix issue with multiple setInterval calls

### DIFF
--- a/lib/dataService.js
+++ b/lib/dataService.js
@@ -39,6 +39,11 @@ class DataService extends EventEmitter {
     }
   }
 
+  stop() {
+    clearInterval(this.timer)
+    delete this.timer
+  }
+
   get isActive() {
     return !!this.timer
   }

--- a/test/dataService.spec.js
+++ b/test/dataService.spec.js
@@ -80,8 +80,8 @@ describe('DataService', () => {
     })
   })
 
-  describe('#start', () => {
-    describe('context -> longPoll', () => {
+  describe('context -> longPoll', () => {
+    describe('#start', () => {
       it('should do a single upfront data pull', (done) => {
 
         //Given a data service
@@ -98,6 +98,19 @@ describe('DataService', () => {
           done()
         }
       })
+    })
+  })
+
+  describe('#stop', () => {
+    it('should stop the dataService', () => {
+      //Given a data service
+      var dataService = dataServiceFactory(validConfig)
+
+      //When the service is stopped after starting
+      dataService.start()
+      dataService.stop()
+
+      dataService.isActive.should.equal(false)
     })
   })
 


### PR DESCRIPTION
This was calling start, which in turn created a new setInterval
so the number of data events emitted increased exponentially!

Took me a while to track down where this was coming from :( but it appears to be all good now.
