### PR TITLE
Add required name field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "",
+  "name": "mappy",
   "engines": {
     "node": "0.10.32"
   },


### PR DESCRIPTION
Mappy can't be included as an npm dependency because the required "name" field is an empty string. See https://github.com/npm/npm/issues/3126
