### PR TITLE
Opt-out of GeoJSON validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,9 +65,8 @@ To work on the project:
 - clone the repo
 - `npm install`
 - In a term run `npm run start:configserver` to start a local config server (serves up config-example folder)
-- export CONFIG_URL=http://127.0.0.1:3002
-- In another terminal run `npm test` to start the test runner
-- In another terminal run `npm run start:dev` to serve the dist dir, bundle files and
+- In another terminal run `export CONFIG_URL=http://127.0.0.1:3002 && npm test` to start the test runner
+- In another terminal run `export CONFIG_URL=http://127.0.0.1:3002 && npm run start:dev` to serve the dist dir, bundle files and
 watch for file changes. Visit `localhost:3000` to see the map
 
 ## Ongoing development notes

--- a/README.md
+++ b/README.md
@@ -206,6 +206,11 @@ Manually tested in:
         "postProcess": {
             "laneSplit": true // true happens on load,
                               // string key or array of keys 'onzoom', ['onzoom', 'onpan']
+        },
+        "filter": {
+          "validateJSON": true // Whether GeoJSON data is validated on the client.
+                             // Turn off for known correct formats (e.g. self-hosted),
+                             // in order to increase client performance.
         }
     }
 ]

--- a/lib/geojsonFeatureFilterer.js
+++ b/lib/geojsonFeatureFilterer.js
@@ -52,7 +52,7 @@ class GeojsonFeatureFilterer {
    * @return {boolean} - true = include, false = exclude
    */
   filter(feature) {
-    if (isValidGeojson(feature) === false) {
+    if (this.config.validateJSON !== false && isValidGeojson(feature) === false) {
       if (typeof console !== 'undefined') {
         console.log('Invalid GeoJSON Feature:');
         console.log(feature);

--- a/test/geojsonFeatureFilterer.spec.js
+++ b/test/geojsonFeatureFilterer.spec.js
@@ -9,7 +9,7 @@ var geojsonFeatureFilterer = rewire('../lib/geojsonFeatureFilterer')
 var factory
 
 describe('the geojsonFeatureFilterer', () => {
-  var filterer, point, linestring, linestring2
+  var filterer, point, invalidPoint, linestring, linestring2
 
   Given('the geojsonFeatureFiltererFactory', () => factory = geojsonFeatureFilterer)
   Given('a valid geojson point object', () => {
@@ -20,6 +20,17 @@ describe('the geojsonFeatureFilterer', () => {
       geometry: {
         type: 'Point',
         coordinates: [172.6325585, -43.4448338]
+      }
+    }
+  })
+  Given('an invalid geojson point object', () => {
+    invalidPoint = {
+      type: 'Feature',
+      id: 'id-1',
+      properties: { show: true },
+      geometry: {
+        type: 'Point',
+        coordinates: [172.6325585] // missing latitude
       }
     }
   })
@@ -85,6 +96,35 @@ describe('the geojsonFeatureFilterer', () => {
         Given('an empty config object', () => conf = null)
         When('a filterer is created using config', () => filterer = factory(conf))
         And('filterer.filter is called with a geojson point feature', () => result = filterer.filter(point))
+        Then('result should be true', () => result.should.equal(true))
+      })
+    })
+
+    describe('GeoJSON validation', () => {
+      scenario('providing a valid GeoJSON object', () => {
+        var conf, filterer, result
+
+        Given('an empty config object', () => conf = {})
+        When('a filterer is created using config', () => filterer = factory(conf))
+        And('filterer.filter is called with an valid geojson point feature', () => result = filterer.filter(point))
+        Then('result should be true', () => result.should.equal(true))
+      })
+
+      scenario('providing a invalid GeoJSON object with validation enabled', () => {
+        var conf, filterer, result
+
+        Given('an empty config object', () => conf = {})
+        When('a filterer is created using config', () => filterer = factory(conf))
+        And('filterer.filter is called with an invalid geojson point feature', () => result = filterer.filter(invalidPoint))
+        Then('result should be false', () => result.should.equal(false))
+      })
+
+      scenario('providing a invalid GeoJSON object with validation disabled', () => {
+        var conf, filterer, result
+
+        Given('a config object with validateJSON=false', () => conf = {validateJSON:false})
+        When('a filterer is created using config', () => filterer = factory(conf))
+        And('filterer.filter is called with an invalid geojson point feature', () => result = filterer.filter(invalidPoint))
         Then('result should be true', () => result.should.equal(true))
       })
     })


### PR DESCRIPTION
If the client and server implementation are controlled by the same developers,
there's no need to validate the GeoJSON format since the data originates from a controlled environment.
This switch is important because we found the GeoJSON validation to be quite a performance hog
on moderate amounts of data (150 points). Hat-tip to @flashbackzoo for the idea.

On a related note, should we separate the JSON example config in the README from the inline comments? They produce invalid JSON which is marked as such in Github's formatting. We should rather have a list of config options in plain markdown.