### PR TITLE
Add/layer pubsub communications

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,72 @@ Defines an array of layers to plot on the map. Currently types `geojson` and
 - Type `geojson` can be used to render a geojson feature collection on the map
 - Type `click` can be used to wire up user clicks to external services
 
+###### Geojson layers
+
+The main way that layers are loaded into mappy is via geojson.
+A geojson layer can be added defining a layer of type = geojson in the layers
+array of the config object
+
+```js
+{
+  layers: [
+    {
+      name: 'my-first-layer',
+      type: 'geojson',
+      enabled: true,
+      dataSource: {
+        url: '/path/to/some/geojson/endpoint',
+        type: 'SinglePoll'
+      }
+    }
+  ]
+}
+```
+
+Assuming that valid geojson was returned, a layer of data should be plotted on
+the map.
+
+###### Geojson layer relationships
+
+If you have multiple layers defined for you map and you would like some layers
+to react to user interactions on another layer you can define pub/sub like
+relationships between layers.
+
+On one layer we specify that any user actions of the specified type(s) performed on
+the layer should be 'emitted' to any other interested layers
+
+```js
+{
+  name: 'my-first-layer',
+  type: 'geojson',
+  notifies: ['click'],
+  //...
+}
+```
+
+Then, on another layer we specify that we are interested in and user clicks on
+'my-first-layer', registering a handler like so:
+
+```js
+{
+  name: 'my-second-layer',
+  type: 'geojson',
+  listens: [
+    {
+      listensTo: 'layer2',
+      type: 'click',
+      handler: function (feature, map) {
+        map.hideGeojsonLayer('layer1')
+      }
+    }
+  ],
+  //...
+}
+```
+
+the registered handler function gets passed the feature that the user clicked on
+as the first parameter and the map object as the second
+
 ##### map
 
 Defines details about the map such as tilelayers

--- a/README.md
+++ b/README.md
@@ -74,12 +74,12 @@ the map.
 
 ###### Geojson layer relationships
 
-If you have multiple layers defined for you map and you would like some layers
+If you have multiple layers defined for your map and you would like some layers
 to react to user interactions on another layer you can define pub/sub like
 relationships between layers.
 
 On one layer we specify that any user actions of the specified type(s) performed on
-the layer should be 'emitted' to any other interested layers
+the layer should be 'notified' to any other interested layers
 
 ```js
 {
@@ -90,7 +90,7 @@ the layer should be 'emitted' to any other interested layers
 }
 ```
 
-Then, on another layer we specify that we are interested in and user clicks on
+Then, on another layer we specify that we are interested in any user clicks on
 'my-first-layer', registering a handler like so:
 
 ```js
@@ -99,10 +99,10 @@ Then, on another layer we specify that we are interested in and user clicks on
   type: 'geojson',
   listens: [
     {
-      listensTo: 'layer2',
+      listensTo: 'my-first-layer',
       type: 'click',
       handler: function (feature, map) {
-        map.hideGeojsonLayer('layer1')
+        map.hideGeojsonLayer('my-second-layer')
       }
     }
   ],

--- a/dist/example-config.js
+++ b/dist/example-config.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var config = {
   map: {
     'domElementId': 'map',
@@ -33,10 +35,19 @@ var config = {
       'name': 'layer1',
       'type': 'geojson',
       'enabled': true,
+      'listens': [
+        {
+          listensTo: 'layer2',
+          type: 'click',
+          handler: function (feature, map) {
+            map.hideGeojsonLayer('layer1')
+          }
+        }
+      ],
       'filter': {
         'geometry': ['Point', 'LineString'],
         'properties': {
-          'highway': ['trunk', 'motorway', 'traffic_signals', 'crossing']
+          'highway': ['traffic_signals']
         }
       },
       'styles': {
@@ -97,6 +108,74 @@ var config = {
       }
     },
     {
+      'name': 'layer2',
+      'type': 'geojson',
+      'enabled': true,
+      'notifies': ['click'],
+      'filter': {
+        'geometry': ['Point', 'LineString'],
+        'properties': {
+          'highway': ['trunk']
+        }
+      },
+      'styles': {
+        'popup': {
+          'template': '<h1>{{highway}}</h1>{{junction}}<br>{{lanes}}<br>{{maxspeed}}<br>{{oneway}}<br>{{id}}<br>',
+          'filter': {
+            'geometry': ['LineString'],
+            'properties': {
+              'highway': ['trunk']
+            }
+          }
+        },
+        'layer': {
+          'general': {
+            'stroke': true,
+            'weight': 15,
+            'opacity': 0.8
+          },
+          'properties': {
+            'highway': {
+              'trunk': {
+                'color': 'blue',
+                'weight': 5,
+                'opacity': 0.2
+              },
+              'motorway': {
+                'color': 'orange'
+              }
+            }
+          }
+        },
+        'icon': {
+          'general': {
+            'iconUrl': '/icons/leaf-green.png',
+            'shadowUrl': '/icons/leaf-shadow.png',
+            'iconSize': [38, 95],
+            'shadowSize': [50, 64],
+            'iconAnchor': [22, 94],
+            'shadowAnchor': [4, 62],
+            'popupAnchor': [-3, -76]
+          },
+          'properties': {
+            'highway': {
+              'traffic_signals': {
+                'iconUrl': '/icons/leaf-red.png'
+              },
+              'crossing': {
+                'iconUrl': '/icons/leaf-orange.png'
+              }
+            }
+          }
+        }
+      },
+      'dataSource': {
+        'url': '//geojson-spew.msapp.co.nz',
+        'type': 'longPoll',
+        'refresh': 10000
+      }
+    },
+    {
       'name': 'click-layer',
       'type': 'click',
       'enabled': true,
@@ -124,9 +203,14 @@ var config = {
         'name': 'layer1',
         'description': 'My Layer',
         'checked': true
+      },
+      {
+        'name': 'layer2',
+        'description': 'My Other Layer',
+        'checked': true
       }
     ]
   }
 };
 
-Mappy.create(config);
+var map = Mappy.create(config);

--- a/lib/geojsonLayerController.js
+++ b/lib/geojsonLayerController.js
@@ -49,7 +49,9 @@ function buildGeojsonLayerOptions(options) {
     popupFilter: (feature) => options.popupFilter.filter(feature),
     style: (properties) => options.layerStylePresenter.present(properties),
     icon: (properties) => options.iconStylePresenter.present(properties),
-    filter: (feature)   => options.geojsonFeatureFilter.filter(feature)
+    filter: (feature)   => options.geojsonFeatureFilter.filter(feature),
+    notifies: options.notifies,
+    listens: options.listens
   }
 }
 
@@ -69,7 +71,9 @@ function buildConfigProcessingOptions(layer, config) {
     popupFilter: config.filterFactory(nn(layer)('styles.popup.filter').val),
     layerStylePresenter: config.stylePresenterFactory(nn(layer)('styles.layer').val),
     iconStylePresenter: config.stylePresenterFactory(nn(layer)('styles.icon').val),
-    geojsonFeatureFilter: config.filterFactory(layer.filter)
+    geojsonFeatureFilter: config.filterFactory(layer.filter),
+    notifies: layer.notifies,
+    listens: layer.listens
   }
 }
 

--- a/lib/mediator.js
+++ b/lib/mediator.js
@@ -1,0 +1,30 @@
+'use strict';
+
+class Mediator {
+
+  constructor() {
+    this._data = {}
+  }
+
+  register(listenerConfig) {
+    var listensTo = listenerConfig.listensTo
+    var type = listenerConfig.type
+    var handler = listenerConfig.handler
+
+    if (!this._data[listensTo]) this._data[listensTo] = {}
+    if (!this._data[listensTo][type]) this._data[listensTo][type] = []
+
+    this._data[listensTo][type].push(handler)
+  }
+
+  notify(eventType, layerName, feature, map) {
+    if (this._data[layerName] && this._data[layerName][eventType]) {
+      var handlers = this._data[layerName][eventType]
+      handlers.forEach((handler) => {
+        handler(feature, map)
+      })
+    }
+  }
+}
+
+module.exports = () => new Mediator()

--- a/test/mediator.spec.js
+++ b/test/mediator.spec.js
@@ -1,0 +1,48 @@
+'use strict';
+
+require('mocha-given')
+var chai      = require('chai')
+var expect    = chai.expect
+var scenario  = describe
+var sinon     = require('sinon')
+
+var mediator = require('../lib/mediator')()
+var EventEmitter = require('events').EventEmitter
+
+class Feature extends EventEmitter {}
+
+describe('The Geojson Layer Mediator', () => {
+
+  scenario('Registering a listening layer', () => {
+    var listenerConfig
+
+    Given(() => {
+      listenerConfig = {
+        listensTo: 'layer1',
+        type: 'click',
+        handler: sinon.spy()
+      }
+    })
+    When(() => mediator.register(listenerConfig))
+    Then(() => expect(mediator._data.layer1.click.length).to.equal(1))
+  })
+
+  scenario('Notifying an event for a click on a feature', () => {
+    var notifierConfig, feature
+
+    Given(() => {
+      mediator.register({
+        listensTo: 'layer1',
+        type: 'click',
+        handler: sinon.spy()
+      })
+    })
+
+    Given(() => notifierConfig = ['click'])
+    Given(() => feature = new Feature())
+    Given(() => feature.on('click', () => mediator.notify('click', 'layer1', {}, {}))) 
+    When(() => feature.emit('click'))
+    Then(() => expect(mediator._data.layer1.click[1]).to.have.been.calledOnce)
+  })
+  
+})

--- a/wrappers/map.js
+++ b/wrappers/map.js
@@ -41,7 +41,7 @@ class Map extends EventEmitter {
     if (config.style)
       options.style = (feature) => config.style(feature.properties)
     if (config.listens) {
-      config.listens.forEach(function (listenerConfig) {
+      config.listens.forEach((listenerConfig) => {
         map.mediator.register(listenerConfig)
       })
     }
@@ -56,7 +56,7 @@ class Map extends EventEmitter {
         }
 
         if (config.notifies) {
-          config.notifies.forEach(function (eventType) {
+          config.notifies.forEach((eventType) => {
             layer.on(eventType, () => map.mediator.notify(eventType, name, feature, map))
           })
         }

--- a/wrappers/map.js
+++ b/wrappers/map.js
@@ -3,6 +3,7 @@
 var L            = require('../vendor/leaflet.js')
 var EventEmitter = require('events').EventEmitter
 var mapTileLayer = require('./tilelayer')
+var mediator     = require('../lib/mediator')
 
 L.Icon.Default.imagePath = 'http://cdn.leafletjs.com/leaflet-0.7/images'
 
@@ -16,6 +17,7 @@ class Map extends EventEmitter {
     this.tileLayers    = {}
     this.geojsonLayers = {}
     this.map.on('click', (event) => this.emit('click', event))
+    this.mediator      = mediator()
   }
 
   /**
@@ -35,15 +37,29 @@ class Map extends EventEmitter {
    */
   setGeojsonLayer(name, config) {
     var options = {}
+    var map = this
     if (config.style)
       options.style = (feature) => config.style(feature.properties)
-    if (config.popup) {
+    if (config.listens) {
+      config.listens.forEach(function (listenerConfig) {
+        map.mediator.register(listenerConfig)
+      })
+    }
+    if (config.popup || config.notifies) {
       options.onEachFeature = (feature, layer) => {
-        if (!config.popupFilter || config.popupFilter(feature))
+        if (!config.popupFilter || config.popupFilter(feature)) {
+
           // don't bind the feature popup if it isn't defined in config
           if (typeof config.popup(feature.properties) !== 'undefined') {
             layer.bindPopup(config.popup(feature.properties))
           }
+        }
+
+        if (config.notifies) {
+          config.notifies.forEach(function (eventType) {
+            layer.on(eventType, () => map.mediator.notify(eventType, name, feature, map))
+          })
+        }
       }
     }
     if (config.icon)


### PR DESCRIPTION
Adds ability to define handlers for inter-layer events. For example, if you click on a feature on one layer, you could possibly show/hide another layer.

WORK IN PROGRESS:

Please take a look @digitalsadhu, let me know if you're happy.

TODO:
- [x] Update Readme to reflect new feature