### PR TITLE
Add/separate datasource config #66

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,10 +294,6 @@ Manually tested in:
             }
         ],
         dataSource: 'name-of-defined-dataSource'
-        postProcess: {
-            laneSplit: true // true happens on load,
-                            // string key or array of keys 'onzoom', ['onzoom', 'onpan']
-        }
     }
 ]
 ```

--- a/README.md
+++ b/README.md
@@ -39,6 +39,28 @@ Configuration is a javascript object with three properties: map, layers and key
 
 Defines the map key (optional)
 
+##### dataSources
+
+Defines the data sources that the layers can use.
+
+Data source definitions should be in format:
+```js
+{
+  dataSources: [
+    {
+      name: 'my-api',
+      type: 'longPoll' // longPoll or singlePoll
+      refresh: 10000   // Interval to refresh the data from the endpoint, only required for longPoll
+      request: {
+        url: '/path/to/some/geojson/endpoint'
+        // other options for xhr module (https://github.com/Raynos/xhr) can be passed in here
+      }
+    }
+  ]
+}
+
+```
+
 ##### layers
 
 Defines an array of layers to plot on the map. Currently types `geojson` and
@@ -59,13 +81,7 @@ array of the config object
     {
       name: 'my-first-layer',
       type: 'geojson',
-      enabled: true,
-      dataSource: {
-        request: {
-          url: '/path/to/some/geojson/endpoint'
-        },
-        type: 'SinglePoll'
-      }
+      dataSource: 'my-api'
     }
   ]
 }
@@ -277,16 +293,10 @@ Manually tested in:
                 type: 'cluster'
             }
         ],
-        dataSource: {
-            request: {
-                url: '...'
-            },
-            type: 'longPoll',
-            refresh: 10000
-        }
+        dataSource: 'name-of-defined-dataSource'
         postProcess: {
             laneSplit: true // true happens on load,
-                              // string key or array of keys 'onzoom', ['onzoom', 'onpan']
+                            // string key or array of keys 'onzoom', ['onzoom', 'onpan']
         }
     }
 ]

--- a/dist/example-config.js
+++ b/dist/example-config.js
@@ -102,13 +102,7 @@ var config = {
           cluster: true
         }
       },
-      dataSource: {
-        request: {
-          url: '//geojson-spew.msapp.co.nz'
-        },
-        type: 'longPoll',
-        refresh: 10000
-      }
+      dataSource: 'geojson-spew'
     },
     {
       name: 'layer2',
@@ -172,13 +166,7 @@ var config = {
           }
         }
       },
-      dataSource: {
-        request: {
-          url: '//geojson-spew.msapp.co.nz'
-        },
-        type: 'longPoll',
-        refresh: 10000
-      }
+      dataSource: 'geojson-spew'
     },
     {
       name: 'click-layer',
@@ -194,12 +182,24 @@ var config = {
           }
         }
       },
-      dataSource: {
-        request: {
-          url: '//parsnip.msapp.co.nz/{x}/{y}'
-        },
-        type: 'singlePoll'
-      }
+      dataSource: 'parsnip'
+    }
+  ],
+  dataSources: [
+    {
+      name: 'geojson-spew',
+      request: {
+        url: '//geojson-spew.msapp.co.nz'
+      },
+      type: 'longPoll',
+      refresh: 10000
+    },
+    {
+      name: 'parsnip',
+      request: {
+        url: '//parsnip.msapp.co.nz/{x}/{y}'
+      },
+      type: 'singlePoll'
     }
   ],
   key: {

--- a/lib/config.js
+++ b/lib/config.js
@@ -7,9 +7,10 @@ class Config {
 
   constructor(config) {
 
-    this.map    = config.map
-    this.layers = config.layers
-    this.key    = config.key
+    this.map         = config.map
+    this.layers      = config.layers
+    this.key         = config.key
+    this.dataSources = config.dataSources
 
     assert(typeof this.map !== 'undefined', true, 'map config must be present')
     this.validateMapConfig()
@@ -20,6 +21,10 @@ class Config {
 
     if (typeof this.key !== 'undefined') {
       this.validateKeyConfig()
+    }
+
+    if (typeof this.dataSources !== 'undefined') {
+      this.validateDataSourceConfig()
     }
   }
 
@@ -54,6 +59,17 @@ class Config {
       'key config property `layers` must be defined (as an array)')
   }
 
+  validateDataSourceConfig() {
+    assert(util.isArray(this.dataSources), 'dataSources config must be an array')
+    this.dataSources.forEach((dataSource) => {
+      assert.equal(typeof dataSource, 'object', 'each dataSource config item must be an object')
+      assert(dataSource.name, '`name` property must be defined for each dataSource config')
+      assert(dataSource.type, '`type` property must be defined for each dataSource config')
+      assert(dataSource.request, '`request` property must be defined for each dataSource config')
+      assert(dataSource.request.url, '`url` property must be defined for each dataSource request config')
+    })
+  }
+
   getLayers() {
     return this.layers
   }
@@ -70,6 +86,10 @@ class Config {
 
   getKey() {
     return this.key
+  }
+
+  getDataSources() {
+    return this.dataSources
   }
 }
 

--- a/lib/dataServiceController.js
+++ b/lib/dataServiceController.js
@@ -1,5 +1,7 @@
 'use strict';
 
+var assert = require('assert')
+
 var dataServiceFactory = require('./dataService')
 
 function createDataServices(config) {
@@ -14,8 +16,8 @@ function createDataServices(config) {
 
 /**
  * DataService controller.
- * Provides an getDataServiceForLayer method to take a layer config and
- * return a predefined DataService or create a new one
+ * Provides a getDataServiceForLayer method to take a layer config and
+ * return a predefined DataService
  */
 class DataServiceController {
 
@@ -26,9 +28,17 @@ class DataServiceController {
   constructor(config) {
     this.config = config
 
-    console.error = config
-
     this.dataServices = createDataServices(config)
+  }
+
+  /**
+   * Convenience method to retrieve a dataSource for the given layerConfig definition
+   * Also verifies that the layer references a known dataSource
+   */
+  getDataServiceForLayer(layerConfig) {
+    assert.ok(!!this.dataServices[layerConfig.dataSource], 'Layer ' + layerConfig.name + ' specifies a dataSource that doesn\'t exist')
+
+    return this.dataServices[layerConfig.dataSource]
   }
 }
 

--- a/lib/dataServiceController.js
+++ b/lib/dataServiceController.js
@@ -1,0 +1,46 @@
+'use strict';
+
+var dataServiceFactory = require('./dataService')
+
+function createDataServices(config) {
+  var dataServices = {}
+
+  config.forEach((dsConfig) => {
+    dataServices[dsConfig.name] = {
+      dataService: dataServiceFactory(dsConfig),
+      config: dsConfig
+    }
+  })
+
+  return dataServices
+}
+
+/**
+ * DataService controller.
+ * Provides an getDataServiceForLayer method to take a layer config and
+ * return a predefined DataService or create a new one
+ */
+class DataServiceController {
+
+  /**
+   * @constructor
+   * @param {object} config
+   */
+  constructor(config) {
+    this.config = config
+
+    console.error = config
+
+    this.dataServices = createDataServices(config)
+  }
+}
+
+
+/**
+ * Module entry point. Validates config object input using asserts
+ * @param {object} config
+ * @return {DataServiceController}
+ */
+module.exports = (config) => {
+  return new DataServiceController(config)
+}

--- a/lib/dataServiceController.js
+++ b/lib/dataServiceController.js
@@ -6,10 +6,7 @@ function createDataServices(config) {
   var dataServices = {}
 
   config.forEach((dsConfig) => {
-    dataServices[dsConfig.name] = {
-      dataService: dataServiceFactory(dsConfig),
-      config: dsConfig
-    }
+    dataServices[dsConfig.name] = dataServiceFactory(dsConfig)
   })
 
   return dataServices

--- a/lib/dataServiceController.js
+++ b/lib/dataServiceController.js
@@ -26,9 +26,9 @@ class DataServiceController {
    * @param {object} config
    */
   constructor(config) {
-    this.config = config
+    this.config = config || []
 
-    this.dataServices = createDataServices(config)
+    this.dataServices = createDataServices(this.config)
   }
 
   /**
@@ -36,7 +36,7 @@ class DataServiceController {
    * Also verifies that the layer references a known dataSource
    */
   getDataServiceForLayer(layerConfig) {
-    assert.ok(!!this.dataServices[layerConfig.dataSource], 'Layer ' + layerConfig.name + ' specifies a dataSource that doesn\'t exist')
+    assert.ok(!!this.dataServices[layerConfig.dataSource], 'Layer `' + layerConfig.name + '` specifies a dataSource that doesn\'t exist')
 
     return this.dataServices[layerConfig.dataSource]
   }

--- a/lib/geojsonLayerController.js
+++ b/lib/geojsonLayerController.js
@@ -8,8 +8,8 @@ var nn     = require('nevernull')
  * Magic strings object that fills the role of consts
  */
 var messages = {
-  'map': '`map` must be a function',
-  'dataServiceFactory': '`dataServiceFactory` must be a function',
+  'map': '`map` must be an object',
+  'dataServiceController': '`dataServiceController` must be an object',
   'popupPresenterFactory': '`popupPresenterFactory` must be a function',
   'stylePresenterFactory': '`stylePresenterFactory` must be a function',
   'filterFactory': '`filterFactory` must be a function',
@@ -56,7 +56,7 @@ function buildConfigProcessingOptions(layer, config) {
     name: layer.name,
     map: config.map,
     key: config.keyController,
-    dataService: config.dataServiceFactory(layer.dataSource),
+    dataService: config.dataServiceController.getDataServiceForLayer(layer),
     popupPresenter: config.popupPresenterFactory(nn(layer)('styles.popup').val),
     popupFilter: config.filterFactory(nn(layer)('styles.popup.filter').val),
     layerStylePresenter: config.stylePresenterFactory(nn(layer)('styles.layer').val),
@@ -133,7 +133,7 @@ class GeojsonLayerController {
  */
 module.exports = (config) => {
   assert.equal(typeof(config.map), 'object', messages.map)
-  assert.equal(typeof(config.dataServiceFactory), 'function', messages.dataServiceFactory)
+  assert.equal(typeof(config.dataServiceController), 'object', messages.dataServiceController)
   assert.equal(typeof(config.popupPresenterFactory), 'function', messages.popupPresenterFactory)
   assert.equal(typeof(config.stylePresenterFactory), 'function', messages.stylePresenterFactory)
   assert.equal(typeof(config.filterFactory), 'function', messages.filterFactory)

--- a/lib/main.js
+++ b/lib/main.js
@@ -11,18 +11,22 @@ var tileLayerManager       = require('./tileLayerManager')
 var mapKeyController       = require('./keyController')
 var geojsonLayerController = require('./geojsonLayerController')
 var tileLayerController    = require('./tileLayerController')
+var dataServiceController  = require('./dataServiceController')
 
 var create = function (config) {
   config = new ConfigParser(config)
-  var mapConfig    = config.getMap()
-  var keyConfig    = config.getKey()
-  var layerConfigs = config.getLayers()
-  var map          = mapFactory(mapConfig)
+  var mapConfig         = config.getMap()
+  var keyConfig         = config.getKey()
+  var layerConfigs      = config.getLayers()
+  var dataSourceConfigs = config.getDataSources()
+  var map               = mapFactory(mapConfig)
 
   tileLayerController({
     map: map,
     manager: tileLayerManager(mapConfig.tileLayers)
   })
+
+  dataServiceController = dataServiceController(dataSourceConfigs)
 
   function clickLayer(layerConfig) {
     var layerStylePresenter = stylePresenterFactory(layerConfig.styles.layer)
@@ -60,7 +64,7 @@ var create = function (config) {
     geojsonLayerController({
       map: map,
       keyController: keyController,
-      dataServiceFactory: dataServiceFactory,
+      dataServiceController: dataServiceController,
       popupPresenterFactory: popupPresenterFactory,
       filterFactory: filterFactory,
       stylePresenterFactory: stylePresenterFactory

--- a/lib/main.js
+++ b/lib/main.js
@@ -30,15 +30,13 @@ var create = function (config) {
 
   function clickLayer(layerConfig) {
     var layerStylePresenter = stylePresenterFactory(layerConfig.styles.layer)
+    var dataService = dataServiceController.getDataServiceForLayer(layerConfig)
 
     map.on('click', (event) => {
       var lng         = event.latlng.lng
       var lat         = event.latlng.lat
-      var config      = JSON.parse(JSON.stringify(layerConfig.dataSource))
-      var dataService
 
-      config.request.url  = config.request.url.replace('{x}', lng).replace('{y}', lat)
-      dataService = dataServiceFactory(config)
+      dataService.url = dataService.url.replace('{x}', lng).replace('{y}', lat)
       dataService.on('data', () => {
         map.setGeojsonLayer(layerConfig.name, {
           geojson: dataService.getData(),

--- a/lib/main.js
+++ b/lib/main.js
@@ -44,7 +44,7 @@ var create = function (config) {
       var lng         = event.latlng.lng
       var lat         = event.latlng.lat
 
-      dataService.url = dataService.url.replace('{x}', lng).replace('{y}', lat)
+      dataService.config.request.url = dataService.url.replace('{x}', lng).replace('{y}', lat)
       dataService.start()
     })
   }

--- a/lib/main.js
+++ b/lib/main.js
@@ -32,19 +32,19 @@ var create = function (config) {
     var layerStylePresenter = stylePresenterFactory(layerConfig.styles.layer)
     var dataService = dataServiceController.getDataServiceForLayer(layerConfig)
 
+    dataService.on('data', () => {
+      map.setGeojsonLayer(layerConfig.name, {
+        geojson: dataService.getData(),
+        style: (properties) => layerStylePresenter.present(properties)
+      })
+      map.showGeojsonLayer(layerConfig.name)
+    })
+
     map.on('click', (event) => {
       var lng         = event.latlng.lng
       var lat         = event.latlng.lat
 
       dataService.url = dataService.url.replace('{x}', lng).replace('{y}', lat)
-      dataService.on('data', () => {
-        map.setGeojsonLayer(layerConfig.name, {
-          geojson: dataService.getData(),
-          style: (properties) => layerStylePresenter.present(properties)
-        })
-        map.showGeojsonLayer(layerConfig.name)
-      })
-
       dataService.start()
     })
   }

--- a/test/config.spec.js
+++ b/test/config.spec.js
@@ -30,9 +30,7 @@ var configObject = {
     {
       name: 'name',
       type: 'type',
-      dataSource: {
-        name: 'dataSource1'
-      }
+      dataSource: 'dataSource1'
     }
   ],
   key: {
@@ -57,6 +55,7 @@ describe('Config', () => {
       //Then
       layers.should.be.an('array')
       layers[0].name.should.be.a('string')
+      layers[0].dataSource.should.be.a('string')
     })
   })
 

--- a/test/config.spec.js
+++ b/test/config.spec.js
@@ -9,6 +9,15 @@ require('chai').should()
 var ConfigParser = require('../lib/config')
 
 var configObject = {
+  dataSources: [
+    {
+      name: 'dataSource1',
+      type: 'longPoll',
+      request: {
+        url: '...'
+      }
+    }
+  ],
   map: {
     domElementId: 'id',
     tileLayers: {
@@ -21,7 +30,9 @@ var configObject = {
     {
       name: 'name',
       type: 'type',
-      dataSource: 'dataSource'
+      dataSource: {
+        name: 'dataSource1'
+      }
     }
   ],
   key: {
@@ -73,6 +84,21 @@ describe('Config', () => {
       key.should.be.an('object')
       key.title.should.be.a('string')
       key.domElementId.should.be.a('string')
+    })
+  })
+
+  describe('#getDataSources', () => {
+    it('should return data source config object', () => {
+      //Given
+
+      //When
+      var dataSources = config.getDataSources()
+
+      //Then
+      dataSources.should.be.an('array')
+      dataSources[0].name.should.be.a('string')
+      dataSources[0].type.should.be.a('string')
+      dataSources[0].request.should.be.an('object')
     })
   })
 

--- a/test/dataServiceController.spec.js
+++ b/test/dataServiceController.spec.js
@@ -1,0 +1,32 @@
+'use strict';
+
+require('mocha-given')
+var chai    = require('chai')
+var expect  = chai.expect
+var scenario = describe
+
+var dataServiceControllerFactory = require('../lib/dataServiceController')
+
+var dataServicesConfig = [
+  {
+    name: 'dataSource1',
+    type: 'singlePoll',
+    request: {
+      url: '...'
+    }
+  }
+]
+
+var dataServiceController = dataServiceControllerFactory(dataServicesConfig)
+
+describe('The DataService Controller', () => {
+
+  scenario('Creating DataServices from config', () => {
+    var firstService
+
+    Given(() => firstService = dataServiceController.dataServices[dataServicesConfig[0].name])
+    Then(() => expect(firstService).to.be.an('object'))
+    And(() => expect(firstService.config).to.be.an('object'))
+    And(() => expect(firstService.dataService).to.be.an('object'))
+  })
+})

--- a/test/dataServiceController.spec.js
+++ b/test/dataServiceController.spec.js
@@ -26,7 +26,18 @@ describe('The DataService Controller', () => {
 
     Given(() => firstService = dataServiceController.dataServices[dataServicesConfig[0].name])
     Then(() => expect(firstService).to.be.an('object'))
-    And(() => expect(firstService.config).to.be.an('object'))
-    And(() => expect(firstService.dataService).to.be.an('object'))
+  })
+
+  scenario('Getting a DataService for a layer', () => {
+    var dataService
+    var layerConfig
+
+    Given(() => {
+      layerConfig = {
+        dataSource: 'dataSource1'
+      }
+    })
+    When(() => dataService = dataServiceController.getDataServiceForLayer(layerConfig))
+    Then(() => expect(dataService).to.be.an('object'))
   })
 })

--- a/test/geojsonLayerController.spec.js
+++ b/test/geojsonLayerController.spec.js
@@ -28,16 +28,22 @@ class KeyController {
     return !!this.layers[name]
   }
 }
-var dataServices = []
 class DataService extends EventEmitter {
   getData() {}
   start() {}
 }
-var dataServiceFactory = () => {
-  var dataService = new DataService()
-  dataServices.push(dataService)
-  return dataService
+class DataServiceController {
+  constructor() {
+    this.dataServices = []
+  }
+
+  getDataServiceForLayer() {
+    var dataService = new DataService()
+    this.dataServices.push(dataService)
+    return dataService
+  }
 }
+
 var popupPresenterFactory = () => {
   return {}
 }
@@ -52,7 +58,7 @@ var configBuilder = () => {
   return {
     map: new Map(),
     keyController: new KeyController(),
-    dataServiceFactory: dataServiceFactory,
+    dataServiceController: new DataServiceController(),
     popupPresenterFactory: popupPresenterFactory,
     stylePresenterFactory: stylePresenterFactory,
     filterFactory: filterFactory
@@ -111,7 +117,7 @@ describe('geojsonLayerController', () => {
       gjLayerController.addLayersFromConfig(layerConfig)
     })
     And('a data event is triggered', () => {
-      dataServices.forEach((ds) => ds.emit('data'))
+      config.dataServiceController.dataServices.forEach((ds) => ds.emit('data'))
     })
     Then('two layers should have been added to the map', () => expect(spy).to.have.been.calledTwice)
   })
@@ -151,7 +157,7 @@ describe('geojsonLayerController', () => {
       gjLayerController.addLayersFromConfig(layerConfig)
     })
     And('a data event is triggered', () => {
-      dataServices.forEach((ds) => ds.emit('data'))
+      config.dataServiceController.dataServices.forEach((ds) => ds.emit('data'))
     })
     Then('two layers should have been added to the map', () => expect(spy).to.have.been.calledTwice)
   })


### PR DESCRIPTION
Brings in the ability to have 2 layers use the same data, but only request the data once.

@digitalsadhu @matt-in-a-hat Please review and test.

Note: fb8a769 removes the postProcess key from the example config in the README as this feature is not implemented 