### PR TITLE
Allow custom icons in clustering.

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,7 +338,7 @@ the default marker clusterer stylesheet. eg.
           cluster: {
             showCoverageOnHover: false,
             icon: {
-              showClusterCount: true,
+              showClusterCount: true, // if false, specify normal icon options e.g. iconUrl
               iconClass: 'leafy-background',
               iconSize: [38, 95],
               iconAnchor: [22, 94],

--- a/README.md
+++ b/README.md
@@ -316,6 +316,7 @@ cluster: false
 cluster: null
 cluster: undefined
 ```
+If you specify an icon it will override `iconCreateFunction` to create the icon with the given config. If `showClusterCount` is also truthy then it will render div's instead, with the cluster count inside. See the example below, with css to show an image AND cluster count.
 
 **Note:** If you want to use clustering with the default styling you will need to include
 the default marker clusterer stylesheet. eg.
@@ -336,14 +337,34 @@ the default marker clusterer stylesheet. eg.
         icon: {
           cluster: {
             showCoverageOnHover: false,
-            iconCreateFunction: function(cluster) {
-              return new L.DivIcon({html: '<b>' + cluster.getChildCount() + '</b>'});
+            icon: {
+              showClusterCount: true,
+              iconClass: 'leafy-background',
+              iconSize: [38, 95],
+              iconAnchor: [22, 94],
+              popupAnchor: [-3, -76]
             }
           }
         }
       }
     }
   ]
+}
+```
+with CSS for the cluster count icon
+```css
+.leaflet-div-icon {
+  background-color: transparent;
+  border: none;
+}
+.leafy-background {
+  background-image: url(/icons/leaf-green.png);
+  width: 100%;
+  height: 100%;
+}
+.leafy-background .cluster-count {
+  text-align: center;
+  padding-top: 15px;
 }
 ```
 

--- a/dist/css/cluster-example.css
+++ b/dist/css/cluster-example.css
@@ -1,0 +1,13 @@
+.leaflet-div-icon {
+  background-color: transparent;
+  border: none;
+}
+.leafy-background {
+  background-image: url(/icons/leaf-green.png);
+  width: 100%;
+  height: 100%;
+}
+.leafy-background .cluster-count {
+  text-align: center;
+  padding-top: 15px;
+}

--- a/dist/example-config.js
+++ b/dist/example-config.js
@@ -99,7 +99,16 @@ var config = {
               }
             }
           },
-          cluster: true
+          cluster: {
+            showCoverageOnHover: false,
+            icon: {
+              showClusterCount: true,
+              iconClass: 'leafy-background',
+              iconSize: [38, 95],
+              iconAnchor: [22, 94],
+              popupAnchor: [-3, -76]
+            }
+          }
         }
       },
       dataSource: 'geojson-spew'

--- a/dist/index.html
+++ b/dist/index.html
@@ -4,6 +4,7 @@
   <title>Map test</title>
   <link rel="stylesheet" href="//cdn.leafletjs.com/leaflet-0.7.3/leaflet.css" />
   <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/leaflet.markercluster/0.4.0/MarkerCluster.Default.css" />
+  <link rel="stylesheet" href="/css/cluster-example.css" />
   <!-- If using google basemaps -->
   <!-- <script src="//maps.google.com/maps/api/js?v=3&sensor=false"></script> -->
   <style type="text/css">

--- a/wrappers/map.js
+++ b/wrappers/map.js
@@ -5,6 +5,7 @@ require('../vendor/leaflet.markercluster-src.js')(L)
 var EventEmitter = require('events').EventEmitter
 var mapTileLayer = require('./tilelayer')
 var mediator     = require('../lib/mediator')
+var nn           = require('nevernull')
 
 L.Icon.Default.imagePath = 'http://cdn.leafletjs.com/leaflet-0.7/images'
 
@@ -81,12 +82,12 @@ class Map extends EventEmitter {
 
     // if clustering is defined then add a marker cluster layer
     // else add a geoJson layer
-    if (typeof config.cluster !== 'undefined' && config.cluster) {
+    if (nn(config)('cluster').val) {
 
       // if an icon is supplied use it
       // unless showClusterCount is also specified, then show a DivIcon with supplied config
-      if (typeof config.cluster.icon !== 'undefined' && config.cluster.icon) {
-        if (typeof config.cluster.icon.showClusterCount !== 'undefined' && config.cluster.icon.showClusterCount) {
+      if (nn(config)('cluster.icon').val) {
+        if (nn(config)('cluster.icon.showClusterCount').val) {
           config.cluster.iconCreateFunction = function (cluster) {
             var iconClass = config.cluster.icon.iconClass !== 'undefined' ? config.cluster.icon.iconClass : 'cluster-icon'
 

--- a/wrappers/map.js
+++ b/wrappers/map.js
@@ -78,12 +78,30 @@ class Map extends EventEmitter {
       this.geojsonLayers[name].removeFrom(this.map)
       delete this.geojsonLayers[name]
     }
-    
+
     // if clustering is defined then add a marker cluster layer
     // else add a geoJson layer
     if (typeof config.cluster !== 'undefined' && config.cluster) {
-      layer = new L.MarkerClusterGroup(config.cluster);
-      layer.addLayer(L.geoJson(config.geojson, options));
+
+      // if an icon is supplied use it
+      // unless showClusterCount is also specified, then show a DivIcon with supplied config
+      if (typeof config.cluster.icon !== 'undefined' && config.cluster.icon) {
+        if (typeof config.cluster.icon.showClusterCount !== 'undefined' && config.cluster.icon.showClusterCount) {
+          config.cluster.iconCreateFunction = function (cluster) {
+            var iconClass = config.cluster.icon.iconClass !== 'undefined' ? config.cluster.icon.iconClass : 'cluster-icon'
+
+            config.cluster.icon.html = '<div class="' + iconClass + '"><div class="cluster-count">' + cluster.getChildCount() + '</div></div>'
+            return L.divIcon(config.cluster.icon)
+          }
+        } else {
+          config.cluster.iconCreateFunction = function () {
+            return L.icon(config.cluster.icon)
+          }
+        }
+      }
+
+      layer = new L.MarkerClusterGroup(config.cluster)
+      layer.addLayer(L.geoJson(config.geojson, options))
     } else {
       layer = L.geoJson(config.geojson, options)
     }


### PR DESCRIPTION
We couldn't specify iconCreateFunction in the config because we don't have access to L.
Now we can just specify a usual icon config, or we can specify to show cluster count, in which case we can use css to style the icon.