### PR TITLE
Fix/ie9 bug

### DIFF
--- a/dist/example-config.js
+++ b/dist/example-config.js
@@ -1,232 +1,236 @@
 'use strict';
 
-var config = {
-  map: {
-    domElementId: 'map',
-    tileLayers: {
-      baseTiles: {
-        url: '//{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
-        attribution: '',
-        maxZoom: 18,
-        zIndex: 10,
-        time: {
-          on: '00:00',
-          off: '08:46'
-        }
-      },
-      auxTiles: {
-        url: '//{s}.tiles.mapbox.com/v3/digitalsadhu.jbf3mhe1/{z}/{x}/{y}.png',
-        attribution: '',
-        maxZoom: 18,
-        zIndex: 10,
-        time: {
-          on: '08:46',
-          off: '23:59'
-        }
-      }
-    },
-    bounds: [
-      [-43.577988,172.515934],
-      [-43.461397,172.749529]
-    ]
-  },
-  layers: [
-    {
-      name: 'layer1',
-      type: 'geojson',
-      enabled: true,
-      listens: [
-        {
-          listensTo: 'layer2',
-          type: 'click',
-          handler: function (feature, map) {
-            map.hideGeojsonLayer('layer1')
-          }
-        }
-      ],
-      filter: {
-        geometry: ['Point', 'LineString'],
-        properties: {
-          highway: ['traffic_signals']
-        }
-      },
-      styles: {
-        popup: {
-          template: '<h1>{{highway}}</h1>{{junction}}<br>{{lanes}}<br>{{maxspeed}}<br>{{oneway}}<br>{{id}}<br>',
-          filter: {
-            geometry: ['LineString'],
-            properties: {
-              highway: ['trunk']
-            }
+window.onload = function () {
+
+  var config = {
+    map: {
+      domElementId: 'map',
+      tileLayers: {
+        baseTiles: {
+          url: '//{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
+          attribution: '',
+          maxZoom: 18,
+          zIndex: 10,
+          time: {
+            on: '00:00',
+            off: '08:46'
           }
         },
-        layer: {
-          general: {
-            stroke: true,
-            weight: 15,
-            opacity: 0.8
-          },
-          properties: {
-            highway: {
-              trunk: {
-                color: 'green',
-                weight: 5,
-                opacity: 0.2
-              },
-              motorway: {
-                color: 'red'
-              }
-            }
-          }
-        },
-        icon: {
-          general: {
-            iconUrl: '/icons/leaf-green.png',
-            shadowUrl: '/icons/leaf-shadow.png',
-            iconSize: [38, 95],
-            shadowSize: [50, 64],
-            iconAnchor: [22, 94],
-            shadowAnchor: [4, 62],
-            popupAnchor: [-3, -76]
-          },
-          properties: {
-            highway: {
-              traffic_signals: {
-                iconUrl: '/icons/leaf-red.png'
-              },
-              crossing: {
-                iconUrl: '/icons/leaf-orange.png'
-              }
-            }
-          },
-          cluster: {
-            showCoverageOnHover: false,
-            icon: {
-              showClusterCount: true,
-              iconClass: 'leafy-background',
-              iconSize: [38, 95],
-              iconAnchor: [22, 94],
-              popupAnchor: [-3, -76]
-            }
+        auxTiles: {
+          url: '//{s}.tiles.mapbox.com/v3/digitalsadhu.jbf3mhe1/{z}/{x}/{y}.png',
+          attribution: '',
+          maxZoom: 18,
+          zIndex: 10,
+          time: {
+            on: '08:46',
+            off: '23:59'
           }
         }
       },
-      dataSource: 'geojson-spew'
+      bounds: [
+        [-43.577988,172.515934],
+        [-43.461397,172.749529]
+      ]
     },
-    {
-      name: 'layer2',
-      type: 'geojson',
-      enabled: true,
-      notifies: ['click'],
-      filter: {
-        geometry: ['Point', 'LineString'],
-        properties: {
-          highway: ['trunk']
-        }
-      },
-      styles: {
-        popup: {
-          template: '<h1>{{highway}}</h1>{{junction}}<br>{{lanes}}<br>{{maxspeed}}<br>{{oneway}}<br>{{id}}<br>',
-          filter: {
-            geometry: ['LineString'],
-            properties: {
-              highway: ['trunk']
-            }
-          }
-        },
-        layer: {
-          general: {
-            stroke: true,
-            weight: 15,
-            opacity: 0.8
-          },
-          properties: {
-            highway: {
-              trunk: {
-                color: 'blue',
-                weight: 5,
-                opacity: 0.2
-              },
-              motorway: {
-                color: 'orange'
-              }
-            }
-          }
-        },
-        icon: {
-          general: {
-            iconUrl: '/icons/leaf-green.png',
-            shadowUrl: '/icons/leaf-shadow.png',
-            iconSize: [38, 95],
-            shadowSize: [50, 64],
-            iconAnchor: [22, 94],
-            shadowAnchor: [4, 62],
-            popupAnchor: [-3, -76]
-          },
-          properties: {
-            highway: {
-              traffic_signals: {
-                iconUrl: '/icons/leaf-red.png'
-              },
-              crossing: {
-                iconUrl: '/icons/leaf-orange.png'
-              }
-            }
-          }
-        }
-      },
-      dataSource: 'geojson-spew'
-    },
-    {
-      name: 'click-layer',
-      type: 'click',
-      enabled: true,
-      styles: {
-        layer: {
-          general: {
-            stroke: true,
-            weight: 1,
-            opacity: 0.8,
-            color: '#000000'
-          }
-        }
-      },
-      dataSource: 'parsnip'
-    }
-  ],
-  dataSources: [
-    {
-      name: 'geojson-spew',
-      request: {
-        url: '//geojson-spew.msapp.co.nz'
-      },
-      type: 'longPoll',
-      refresh: 10000
-    },
-    {
-      name: 'parsnip',
-      request: {
-        url: '//parsnip.msapp.co.nz/{x}/{y}'
-      },
-      type: 'singlePoll'
-    }
-  ],
-  key: {
-    domElementId: 'key',
-    title: 'My map key',
     layers: [
       {
         name: 'layer1',
-        description: 'My Layer',
-        checked: true
+        type: 'geojson',
+        enabled: true,
+        listens: [
+          {
+            listensTo: 'layer2',
+            type: 'click',
+            handler: function (feature, map) {
+              map.hideGeojsonLayer('layer1')
+            }
+          }
+        ],
+        filter: {
+          geometry: ['Point', 'LineString'],
+          properties: {
+            highway: ['traffic_signals']
+          }
+        },
+        styles: {
+          popup: {
+            template: '<h1>{{highway}}</h1>{{junction}}<br>{{lanes}}<br>{{maxspeed}}<br>{{oneway}}<br>{{id}}<br>',
+            filter: {
+              geometry: ['LineString'],
+              properties: {
+                highway: ['trunk']
+              }
+            }
+          },
+          layer: {
+            general: {
+              stroke: true,
+              weight: 15,
+              opacity: 0.8
+            },
+            properties: {
+              highway: {
+                trunk: {
+                  color: 'green',
+                  weight: 5,
+                  opacity: 0.2
+                },
+                motorway: {
+                  color: 'red'
+                }
+              }
+            }
+          },
+          icon: {
+            general: {
+              iconUrl: '/icons/leaf-green.png',
+              shadowUrl: '/icons/leaf-shadow.png',
+              iconSize: [38, 95],
+              shadowSize: [50, 64],
+              iconAnchor: [22, 94],
+              shadowAnchor: [4, 62],
+              popupAnchor: [-3, -76]
+            },
+            properties: {
+              highway: {
+                traffic_signals: {
+                  iconUrl: '/icons/leaf-red.png'
+                },
+                crossing: {
+                  iconUrl: '/icons/leaf-orange.png'
+                }
+              }
+            },
+            cluster: {
+              showCoverageOnHover: false,
+              icon: {
+                showClusterCount: true,
+                iconClass: 'leafy-background',
+                iconSize: [38, 95],
+                iconAnchor: [22, 94],
+                popupAnchor: [-3, -76]
+              }
+            }
+          }
+        },
+        dataSource: 'geojson-spew'
       },
       {
         name: 'layer2',
-        description: 'My Other Layer',
-        checked: true
+        type: 'geojson',
+        enabled: true,
+        notifies: ['click'],
+        filter: {
+          geometry: ['Point', 'LineString'],
+          properties: {
+            highway: ['trunk']
+          }
+        },
+        styles: {
+          popup: {
+            template: '<h1>{{highway}}</h1>{{junction}}<br>{{lanes}}<br>{{maxspeed}}<br>{{oneway}}<br>{{id}}<br>',
+            filter: {
+              geometry: ['LineString'],
+              properties: {
+                highway: ['trunk']
+              }
+            }
+          },
+          layer: {
+            general: {
+              stroke: true,
+              weight: 15,
+              opacity: 0.8
+            },
+            properties: {
+              highway: {
+                trunk: {
+                  color: 'blue',
+                  weight: 5,
+                  opacity: 0.2
+                },
+                motorway: {
+                  color: 'orange'
+                }
+              }
+            }
+          },
+          icon: {
+            general: {
+              iconUrl: '/icons/leaf-green.png',
+              shadowUrl: '/icons/leaf-shadow.png',
+              iconSize: [38, 95],
+              shadowSize: [50, 64],
+              iconAnchor: [22, 94],
+              shadowAnchor: [4, 62],
+              popupAnchor: [-3, -76]
+            },
+            properties: {
+              highway: {
+                traffic_signals: {
+                  iconUrl: '/icons/leaf-red.png'
+                },
+                crossing: {
+                  iconUrl: '/icons/leaf-orange.png'
+                }
+              }
+            }
+          }
+        },
+        dataSource: 'geojson-spew'
+      },
+      {
+        name: 'click-layer',
+        type: 'click',
+        enabled: true,
+        styles: {
+          layer: {
+            general: {
+              stroke: true,
+              weight: 1,
+              opacity: 0.8,
+              color: '#000000'
+            }
+          }
+        },
+        dataSource: 'parsnip'
       }
-    ]
-  }
-};
+    ],
+    dataSources: [
+      {
+        name: 'geojson-spew',
+        request: {
+          url: '//geojson-spew.msapp.co.nz'
+        },
+        type: 'longPoll',
+        refresh: 10000
+      },
+      {
+        name: 'parsnip',
+        request: {
+          url: '//parsnip.msapp.co.nz/{x}/{y}'
+        },
+        type: 'singlePoll'
+      }
+    ],
+    key: {
+      domElementId: 'key',
+      title: 'My map key',
+      layers: [
+        {
+          name: 'layer1',
+          description: 'My Layer',
+          checked: true
+        },
+        {
+          name: 'layer2',
+          description: 'My Other Layer',
+          checked: true
+        }
+      ]
+    }
+  };
 
-var map = Mappy.create(config);
+  window.Mappy.create(config);
+
+}

--- a/lib/tileLayerManager.js
+++ b/lib/tileLayerManager.js
@@ -54,7 +54,7 @@ class TileLayerManager extends EventEmitter {
    */
   constructor(config) {
     this.config = config
-    this.layers = new Map()
+    this.layers = {}
     this.interval = null
   }
 
@@ -80,9 +80,9 @@ class TileLayerManager extends EventEmitter {
    * @param {string} layerName
    */
   removeLayer(layerName) {
-    if (!!this.layers.get(layerName)) {
+    if (!!this.layers[layerName]) {
       this.emit('remove', layerName)
-      this.layers.set(layerName, false)
+      this.layers[layerName] = false
     }
   }
 
@@ -92,9 +92,9 @@ class TileLayerManager extends EventEmitter {
    * @param {string} layerName
    */
   addLayer(layerName) {
-    if (!this.layers.get(layerName)) {
+    if (!this.layers[layerName]) {
       this.emit('add', layerName, this.config[layerName])
-      this.layers.set(layerName, true)
+      this.layers[layerName] = true
     }
   }
 


### PR DESCRIPTION
It seems 6to5 does not provide support for the `Map` object type in ie9.
Also found issues with `Mappy.create` getting called before `Mappy` was defined on `window`, so delayed creation with `window.onload` in `example-config` file. 