### PR TITLE
Remove check for isActive, pullData checks enough

### DIFF
--- a/lib/dataService.js
+++ b/lib/dataService.js
@@ -80,14 +80,8 @@ class SinglePollDataService extends DataService {
   }
 
   start() {
-    if (!this.isActive) {
-      this.isActive = true
-      this.pullData()
-    }
-  }
-
-  stop() {
-    this.isActive = false
+    this.isActive = true
+    this.pullData()
   }
 }
 


### PR DESCRIPTION
The start function was checking `if (!isActive)` but we were never setting `isActive` to false after the first data pull. This prevented click layers working after the first click.

The `isActive` check was added in a mistaken attempt to prevent pulling data multiple times from a user spamming the click event, but the parent classes `pullData` does some nice checks for `isLoading` that covers that.