### PR TITLE
Add 'geojson.add' event for adding a geojson layer

### DIFF
--- a/wrappers/map.js
+++ b/wrappers/map.js
@@ -119,8 +119,7 @@ class Map extends EventEmitter {
 
     map.emit('geojson.add', {
       name: name,
-      layer: layer,
-      config: config
+      layer: layer
     })
   }
 

--- a/wrappers/map.js
+++ b/wrappers/map.js
@@ -116,6 +116,12 @@ class Map extends EventEmitter {
     }
 
     this.geojsonLayers[name] = layer
+
+    map.emit('geojson.add', {
+      name: name,
+      layer: layer,
+      config: config
+    })
   }
 
   showGeojsonLayer(name) {


### PR DESCRIPTION
@markstuart @digitalsadhu thoughts?

I'm specifying a couple of layers, each with their own data source, but I want the map to zoom in to 1 of the layers. The initial map bounds are only defined in config, but it needs to be dynamic with the size of the layer. Now I can listen to this event, and if it's the layer I want, fit the map to its bounds.