### PR TITLE
L.Google does not implement function addTo

### DIFF
--- a/wrappers/map.js
+++ b/wrappers/map.js
@@ -30,7 +30,7 @@ class Map extends EventEmitter {
    */
   setTileLayer(name, config) {
     this.tileLayers[name] = mapTileLayer(config.url, config)
-    this.tileLayers[name].addTo(this.map)
+    this.map.addLayer(this.tileLayers[name])
   }
 
   removeTileLayer(name) {


### PR DESCRIPTION
The google plugin provided by `leaflet-plugins` creates a L.Class extension called L.Google. It seems like it should provide the same interface as L.TileLayer... but no.

Tested this change locally using `npm link` with configuration for Mapbox and Google tilelayers, this change works for both.